### PR TITLE
DCD-261: Remove redundant DB pooling params

### DIFF
--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -60,17 +60,6 @@ Metadata:
             - TomcatContextPath
             - CatalinaOpts
             - JvmHeapOverride
-            - DBPoolMaxSize
-            - DBPoolMinSize
-            - DBMaxIdle
-            - DBMaxWaitMillis
-            - DBMinEvictableIdleTimeMillis
-            - DBMinIdle
-            - DBRemoveAbandoned
-            - DBRemoveAbandonedTimeout
-            - DBTestOnBorrow
-            - DBTestWhileIdle
-            - DBTimeBetweenEvictionRunsMillis
             - MailEnabled
             - TomcatAcceptCount
             - TomcatConnectionTimeout
@@ -112,38 +101,16 @@ Metadata:
         default: RDS Provisioned IOPS
       DBMasterUserPassword:
         default: Master (admin) password *
-      DBMaxIdle:
-        default: DB Maximum Idle
-      DBMaxWaitMillis:
-        default: DB Maximum Wait
-      DBMinEvictableIdleTimeMillis:
-        default: DB Minimum Evictable Idle Time
-      DBMinIdle:
-        default: DB Minimum Idle Connections
       DBMultiAZ:
         default: Enable RDS Multi-AZ deployment
       DBPassword:
         default: Application user database password *
-      DBPoolMaxSize:
-        default: DB Pool Maximum Size
-      DBPoolMinSize:
-        default: DB Pool Minimum Size
-      DBRemoveAbandoned:
-        default: DB Remove Abandoned?
-      DBRemoveAbandonedTimeout:
-        default: DB Remove Abandoned Timeout
       DBStorage:
         default: Database storage
       DBStorageEncrypted:
         default: Database encryption
       DBStorageType:
         default: Database storage type
-      DBTestOnBorrow:
-        default: DB Test On Borrow?
-      DBTestWhileIdle:
-        default: DB Test While Idle?
-      DBTimeBetweenEvictionRunsMillis:
-        default: DB Time Between Eviction Runs
       DeploymentAutomationRepository:
         default: Deployment Automation Git Repository URL
       DeploymentAutomationBranch:
@@ -384,22 +351,6 @@ Parameters:
     MaxLength: 128
     MinLength: 8
     Type: String
-  DBMaxIdle:
-    Default: 20
-    Description: The maximum number of database connections that are allowed to remain idle in the pool
-    Type: Number
-  DBMaxWaitMillis:
-    Default: 10000
-    Description: The length of time (in milliseconds) that Jira is allowed to wait for a database connection to become available (while there are no free ones available in the pool), before returning an error
-    Type: Number
-  DBMinEvictableIdleTimeMillis:
-    Default: 180000
-    Description: The minimum amount of time an object may sit idle in the database connection pool before it is eligible for eviction by the idle object eviction
-    Type: Number
-  DBMinIdle:
-    Default: 10
-    Description: The minimum number of idle database connections that are kept open at any time
-    Type: Number
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
     Default: "true"
@@ -417,25 +368,6 @@ Parameters:
     MinLength: 8
     MaxLength: 128
     NoEcho: true
-    Type: String
-  DBPoolMaxSize:
-    Default: 20
-    Description: The maximum number of database connections that can be opened at any time
-    Type: Number
-  DBPoolMinSize:
-    Default: 20
-    Description: The minimum number of idle database connections that are kept open at any time
-    Type: Number
-  DBRemoveAbandoned:
-    Default: "true"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Flag to remove abandoned database connections if they exceed the Removed Abandoned Timeout
-    Type: String
-  DBRemoveAbandonedTimeout:
-    Default: 60
-    Description: The length of time (in seconds) that a database connection can be idle before it is considered abandoned
     Type: String
   DBStorage:
     Default: 200
@@ -456,24 +388,6 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type (not used for Aurora).
     Type: String
-  DBTestOnBorrow:
-    Default: "false"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Tests if the database connection is valid when it is borrowed from the database connection pool by Jira
-    Type: String
-  DBTestWhileIdle:
-    Default: "true"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Periodically tests if the database connection is valid when it is idle
-    Type: String
-  DBTimeBetweenEvictionRunsMillis:
-    Default: 60000
-    Description: The number of milliseconds to sleep between runs of the idle object eviction thread. When non-positive, no idle object eviction thread will be run
-    Type: Number
   DeploymentAutomationRepository:
     Default: "https://bitbucket.org/atlassian/dc-deployments-automation.git"
     Type: String
@@ -682,22 +596,11 @@ Resources:
         DBInstanceClass: !Ref 'DBInstanceClass'
         DBIops: !Ref 'DBIops'
         DBMasterUserPassword: !Ref 'DBMasterUserPassword'
-        DBMaxIdle: !Ref 'DBMaxIdle'
-        DBMaxWaitMillis: !Ref 'DBMaxWaitMillis'
-        DBMinEvictableIdleTimeMillis: !Ref 'DBMinEvictableIdleTimeMillis'
-        DBMinIdle: !Ref 'DBMinIdle'
         DBMultiAZ: !Ref 'DBMultiAZ'
         DBPassword: !Ref 'DBPassword'
-        DBPoolMaxSize: !Ref 'DBPoolMaxSize'
-        DBPoolMinSize: !Ref 'DBPoolMinSize'
-        DBRemoveAbandoned: !Ref 'DBRemoveAbandoned'
-        DBRemoveAbandonedTimeout: !Ref 'DBRemoveAbandonedTimeout'
         DBStorage: !Ref 'DBStorage'
         DBStorageEncrypted: !Ref 'DBStorageEncrypted'
         DBStorageType: !Ref 'DBStorageType'
-        DBTestOnBorrow: !Ref 'DBTestOnBorrow'
-        DBTestWhileIdle: !Ref 'DBTestWhileIdle'
-        DBTimeBetweenEvictionRunsMillis: !Ref 'DBTimeBetweenEvictionRunsMillis'
         DeploymentAutomationRepository: !Ref 'DeploymentAutomationRepository'
         DeploymentAutomationBranch: !Ref 'DeploymentAutomationBranch'
         DeploymentAutomationKeyName: !Ref 'DeploymentAutomationKeyName'

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -50,17 +50,6 @@ Metadata:
           - TomcatContextPath
           - CatalinaOpts
           - JvmHeapOverride
-          - DBPoolMaxSize
-          - DBPoolMinSize
-          - DBMaxIdle
-          - DBMaxWaitMillis
-          - DBMinEvictableIdleTimeMillis
-          - DBMinIdle
-          - DBRemoveAbandoned
-          - DBRemoveAbandonedTimeout
-          - DBTestOnBorrow
-          - DBTestWhileIdle
-          - DBTimeBetweenEvictionRunsMillis
           - MailEnabled
           - TomcatAcceptCount
           - TomcatConnectionTimeout
@@ -100,38 +89,16 @@ Metadata:
         default: RDS Provisioned IOPS
       DBMasterUserPassword:
         default: Master (admin) password *
-      DBMaxIdle:
-        default: DB Maximum Idle
-      DBMaxWaitMillis:
-        default: DB Maximum Wait
-      DBMinEvictableIdleTimeMillis:
-        default: DB Minimum Evictable Idle Time
-      DBMinIdle:
-        default: DB Minimum Idle Connections
       DBMultiAZ:
         default: Enable RDS Multi-AZ deployment
       DBPassword:
         default: Application user database password *
-      DBPoolMaxSize:
-        default: DB Pool Maximum Size
-      DBPoolMinSize:
-        default: DB Pool Minimum Size
-      DBRemoveAbandoned:
-        default: DB Remove Abandoned?
-      DBRemoveAbandonedTimeout:
-        default: DB Remove Abandoned Timeout
       DBStorage:
         default: Database storage
       DBStorageEncrypted:
         default: Database encryption
       DBStorageType:
         default: Database storage type
-      DBTestOnBorrow:
-        default: DB Test On Borrow?
-      DBTestWhileIdle:
-        default: DB Test While Idle?
-      DBTimeBetweenEvictionRunsMillis:
-        default: DB Time Between Eviction Runs
       DeploymentAutomationRepository:
         default: Deployment Automation Git Repository URL
       DeploymentAutomationBranch:
@@ -366,22 +333,6 @@ Parameters:
     MaxLength: 128
     MinLength: 8
     Type: String
-  DBMaxIdle:
-    Default: 20
-    Description: The maximum number of database connections that are allowed to remain idle in the pool
-    Type: Number
-  DBMaxWaitMillis:
-    Default: 10000
-    Description: The length of time (in milliseconds) that Jira is allowed to wait for a database connection to become available (while there are no free ones available in the pool), before returning an error
-    Type: Number
-  DBMinEvictableIdleTimeMillis:
-    Default: 180000
-    Description: The minimum amount of time an object may sit idle in the database connection pool before it is eligible for eviction by the idle object eviction
-    Type: Number
-  DBMinIdle:
-    Default: 10
-    Description: The minimum number of idle database connections that are kept open at any time
-    Type: Number
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
     Default: "true"
@@ -400,25 +351,6 @@ Parameters:
     MaxLength: 128
     NoEcho: true
     Type: String
-  DBPoolMaxSize:
-    Default: 20
-    Description: The maximum number of database connections that can be opened at any time
-    Type: Number
-  DBPoolMinSize:
-    Default: 20
-    Description: The minimum number of idle database connections that are kept open at any time
-    Type: Number
-  DBRemoveAbandoned:
-    Default: "true"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Flag to remove abandoned database connections if they exceed the Removed Abandoned Timeout
-    Type: String
-  DBRemoveAbandonedTimeout:
-    Default: 60
-    Description: The length of time (in seconds) that a database connection can be idle before it is considered abandoned
-    Type: Number
   DBStorage:
     Default: 200
     Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144 (not used for Aurora).
@@ -438,24 +370,6 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type (not used for Aurora).
     Type: String
-  DBTestOnBorrow:
-    Default: "false"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Tests if the database connection is valid when it is borrowed from the database connection pool by Jira
-    Type: String
-  DBTestWhileIdle:
-    Default: "true"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Periodically tests if the database connection is valid when it is idle
-    Type: String
-  DBTimeBetweenEvictionRunsMillis:
-    Default: 60000
-    Description: The number of milliseconds to sleep between runs of the idle object eviction thread. When non-positive, no idle object eviction thread will be run
-    Type: Number
   DeploymentAutomationRepository:
     Default: "https://bitbucket.org/atlassian/dc-deployments-automation.git"
     Type: String
@@ -1025,19 +939,8 @@ Resources:
                     - !Sub ["ATL_AWS_STACK_NAME=${StackName}", StackName: !Ref "AWS::StackName"]
                     - !Sub ["ATL_CATALINA_OPTS=\"${CatalinaOpts} ${MailOpts}\"", { CatalinaOpts: !Ref CatalinaOpts, MailOpts: !If [DisableMail, '-Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true', ''] }]
                     - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Outputs.RDSEndPointAddress]
-                    - !Sub ["ATL_DB_MAXIDLE=${DBMaxIdle}", DBMaxIdle: !Ref DBMaxIdle]
-                    - !Sub ["ATL_DB_MAXWAITMILLIS=${DBMaxWaitMillis}", DBMaxWaitMillis: !Ref DBMaxWaitMillis]
-                    - !Sub ["ATL_DB_MINEVICTABLEIDLETIMEMILLIS=${DBMinEvictableIdleTimeMillis}", DBMinEvictableIdleTimeMillis: !Ref DBMinEvictableIdleTimeMillis]
-                    - !Sub ["ATL_DB_MINIDLE=${DBMinIdle}", DBMinIdle: !Ref DBMinIdle]
                     - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
-                    - !Sub ["ATL_DB_POOLMAXSIZE=${DBPoolMaxSize}", DBPoolMaxSize: !Ref DBPoolMaxSize]
-                    - !Sub ["ATL_DB_POOLMINSIZE=${DBPoolMinSize}", DBPoolMinSize: !Ref DBPoolMinSize]
                     - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Outputs.RDSEndPointPort]
-                    - !Sub ["ATL_DB_REMOVEABANDONED=${DBRemoveAbandoned}", DBRemoveAbandoned: !Ref DBRemoveAbandoned]
-                    - !Sub ["ATL_DB_REMOVEABANDONEDTIMEOUT=${DBRemoveAbandonedTimeout}", DBRemoveAbandonedTimeout: !Ref DBRemoveAbandonedTimeout]
-                    - !Sub ["ATL_DB_TESTONBORROW=${DBTestOnBorrow}", DBTestOnBorrow: !Ref DBTestOnBorrow]
-                    - !Sub ["ATL_DB_TESTWHILEIDLE=${DBTestWhileIdle}", DBTestWhileIdle: !Ref DBTestWhileIdle]
-                    - !Sub ["ATL_DB_TIMEBETWEENEVICTIONRUNSMILLIS=${DBTimeBetweenEvictionRunsMillis}", DBTimeBetweenEvictionRunsMillis: !Ref DBTimeBetweenEvictionRunsMillis]
                     - !Sub ["ATL_HOSTEDZONE=${HostedZone}", HostedZone: !Ref HostedZone]
                     - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
                     - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/crowd?targetServerType=master", { DBEndpointAddress: !GetAtt DB.Outputs.RDSEndPointAddress, DBEndpointPort: !GetAtt DB.Outputs.RDSEndPointPort }]


### PR DESCRIPTION
Yesterday I went down a DB pool property rabbit hole… Turns out that the params and props removed in this PR end here, at their definition. **They aren't used to further bootstrap Crowd.** 

I’ve confirmed that Crowd simply does not support this behavior and it cannot be configured with these params on installation - similar to the pre-seeding (although fixed with env variables) issue we had. 

To further clarify this I spoke with Marcin Kempa from the Crowd team and he confirmed all of this too, and that this is definitely something that the Crowd team could look at supporting in the future. 

[Associated PR for the Crowd Ansible playbook.](https://bitbucket.org/atlassian/dc-deployments-automation/pull-requests/98/dcd-261-remove-redundant-db-pooling)