### PR TITLE
DCD-261: Remove dynamic autoscaling

### DIFF
--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -1041,6 +1041,7 @@ Resources:
             - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}\n", {Region: !Ref "AWS::Region"}]
             - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", {StackName: !Ref "AWS::StackName"}]
             - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}", {Region: !Ref "AWS::Region"}]
+  # Elastic file system
   ElasticFileSystem:
     Type: AWS::EFS::FileSystem
     Properties:


### PR DESCRIPTION
Dynamic auto-scaling is not defined as a documented feature and nor is it used by the other products. Removing this ability.

> This Quick Start usesAuto Scaling groups, but only to statically control the number of its nodes. We don't recommend that you use Auto Scaling to dynamically scale the size of your cluster. Adding an application node to the cluster usually takes more than 20 minutes, which isn't fast enough to address sudden load spikes.If you can identify any periods of high and low load, you can schedule the application node cluster to scale accordingly. For more information, seeScheduled Scaling for Amazon EC2 Auto Scaling.
