### PR TITLE
DCD deployments repo pinning - SSM proposal

### DIFF
--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -996,7 +996,7 @@ Resources:
                 fi
 
                 ### Ansible repo pinning ###
-                pinned_commit_id=$(aws --region=${AWS::Region} ssm get-parameters --names "$ssm_pin" | jq --raw-output '.Parameters[0] .Value')
+                pinned_commit_id=$(aws --region=${AWS::Region} ssm get-parameters --names "$ssm_pin" | jq --raw-output '.Parameters[0].Value')
 
                 git clone "${DeploymentAutomationRepository}" -b "${DeploymentAutomationBranch}" /opt/atlassian/dc-deployments-automation/
                 cd /opt/atlassian/dc-deployments-automation/


### PR DESCRIPTION
Proposed code changes for using SSM param approach

**Code changes that will:**

- Create a new SSM resource, `AnsibleRepoPinSHA`, that is tied to its associated stack and is initially set with a value of: `latest`
- Provide a new IAM policy so that the value of the `AnsibleRepoPinSHA` resource can be updated
- Check the value of `AnsibleRepoPinSHA` (via cfn Init script) if `latest` update the value to the current `HEAD` `SHA`
- New nodes that join the cluster (on an update) will check the value of `AnsibleRepoPinSHA` and utilize the `SHA` it has been set with
- Checkout `dc-deployments-repo` to the `SHA`

**Assumptions**
- To perform an upgrade of the stack using a different `SHA`, the value assigned to `AnsibleRepoPinSHA` will first need to be manually updated to the favored `SHA` via the SSM UI. The standard upgrade process will then need to be followed i.e. update node count to `0` and scale up again.

**Passing on branch CI plan**
https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSCROWD0-1

Additional details on the mechanism and how it can be used to perform upgrades and downgrades here: https://hello.atlassian.net/wiki/spaces/DCD/pages/708126766/KB+SSM+Parameter+Pinning
