### PR TITLE
DCD-1001: Fix AnsibleRepoPinSHA resource deletion issue 

### DIFF
--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -876,6 +876,7 @@ Resources:
             Statement:
               - Action:
                   - 'ssm:PutParameter'
+                  - 'ssm:DeleteParameter'
                 Effect: Allow
                 Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha"
   ClusterNodeInstanceProfile:


### PR DESCRIPTION
Taskcat reaper was failing to delete the resource AnsibleRepoPinSHA.

This is no longer the case with this fix. Using the confluence stack below as a test case we can see that the resource is now being deleted when the reaper kicks in:

https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?filteringText=&filteringStatus=deleted&viewNested=false&hideStacks=false&stackId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A887764444972%3Astack%2Ftcat-tag-confluence-2651c637%2Fc7652d30-942c-11ea-a8a3-12498e67507f