### PR TITLE
DCD-1051: Gov arn for gov region

### DIFF
--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -926,8 +926,8 @@ Resources:
                   - 'ssm:PutParameter'
                 Effect: Allow
                 Resource: !Sub
-                  - arn:${ArnIdentifier}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
-                  - ArnIdentifier: !If ["GovCloudCondition", "aws-us-gov", "aws"]
+                  - arn:${ArnPartition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
+                  - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
   ClusterNodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
Ran custom Jira CI plan (temporarily updated Jira submodules to point to updated [quickstart-atlassian-services](https://github.com/atlassian/quickstart-atlassian-services/pull/45) and updated [quickstart-amazon-aurora](https://github.com/atlassian/quickstart-amazon-aurora/pull/6)) results for which are below:

https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSJIRA64-JSMOKDEPLOY-9/log

Deploys passed and all but the HTTP acceptance tests which I believe to be a dud (looking at the logs). This run should confirm these AWS partition changes across the board for Jira and the other products; BB, Connie, Crowd.

These changes have also been tested in a Gov account and are shown to work, where we no longer have failing deployments