### PR TITLE
DCD-1051: Refactor code

### DIFF
--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -565,8 +565,6 @@ Conditions:
   UseBastionHost: !And
     - !Equals [!Ref BastionHostRequired, true]
     - !Condition KeyProvided
-  GovCloudCondition:
-    !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
 
 Mappings:
   AWSInstanceType2Arch:
@@ -926,8 +924,7 @@ Resources:
                   - 'ssm:PutParameter'
                 Effect: Allow
                 Resource: !Sub
-                  - arn:${ArnPartition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
-                  - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
+                  - arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/pinned-ansible-sha
   ClusterNodeInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
Simplifying this code

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html

> AWS::Partition
> Returns the partition that the resource is in. For standard AWS regions, the partition is aws. For resources in other > partitions, the partition is aws-partitionname. For example, the partition for resources in the China (Beijing and Ningxia) > region is aws-cn and the partition for resources in the AWS GovCloud (US-West) region is aws-us-gov. 