### PR TITLE
DCD-1004: Add encryption to EFS and EBS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/taskcat_outputs
+taskcat_outputs
 *~
 *.bak
 /.idea

--- a/ci/params/encryption/quickstart-crowd-encrypted-params.json
+++ b/ci/params/encryption/quickstart-crowd-encrypted-params.json
@@ -1,7 +1,7 @@
 [
     {
-        "ParameterKey": "AvailabilityZones",
-        "ParameterValue": "$[taskcat_genaz_2]"
+        "ParameterKey": "InternetFacingLoadBalancer",
+        "ParameterValue": "true"
     },
     {
         "ParameterKey": "DBMasterUserPassword",
@@ -24,31 +24,35 @@
         "ParameterValue": "Provisioned IOPS"
     },
     {
-        "ParameterKey": "CustomDnsName",
-        "ParameterValue": "qscrowdci.awsqs.com"
-    },
-    {
-        "ParameterKey":"QSS3BucketName",
-        "ParameterValue": "$[taskcat_autobucket]"
-    },
-    {
-        "ParameterKey":"QSS3BucketRegion",
-        "ParameterValue": "us-east-1"
-    },
-    {
-        "ParameterKey":"QSS3KeyPrefix",
-        "ParameterValue": "quickstart-atlassian-crowd/"
-    },
-    {
-        "ParameterKey": "AccessCIDR",
-        "ParameterValue": "10.0.0.0/16"
-    },
-    {
         "ParameterKey": "KeyPairName",
         "ParameterValue": "replaced-by-taskcat-override-file"
     },
     {
-        "ParameterKey": "ExportPrefix",
-        "ParameterValue": "TASI"
+        "ParameterKey": "CidrBlock",
+        "ParameterValue": "0.0.0.0/0"
+    },
+    {
+        "ParameterKey": "QSS3BucketName",
+        "ParameterValue": "$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey":"QSS3BucketRegion",
+        "ParameterValue":"us-east-1"
+    },
+    {
+        "ParameterKey": "QSS3KeyPrefix",
+        "ParameterValue": "quickstart-atlassian-crowd/"
+    },
+    {
+        "ParameterKey": "ClusterNodeInstanceType",
+        "ParameterValue": "t3.medium"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.t3.medium"
+    },
+    {
+        "ParameterKey": "EncryptionAtRest",
+        "ParameterValue": "true"
     }
 ]

--- a/ci/params/encryption/quickstart-crowd-not-encrypted-params.json
+++ b/ci/params/encryption/quickstart-crowd-not-encrypted-params.json
@@ -1,7 +1,7 @@
 [
     {
-        "ParameterKey": "AvailabilityZones",
-        "ParameterValue": "$[taskcat_genaz_2]"
+        "ParameterKey": "InternetFacingLoadBalancer",
+        "ParameterValue": "true"
     },
     {
         "ParameterKey": "DBMasterUserPassword",
@@ -24,31 +24,35 @@
         "ParameterValue": "Provisioned IOPS"
     },
     {
-        "ParameterKey": "CustomDnsName",
-        "ParameterValue": "qscrowdci.awsqs.com"
-    },
-    {
-        "ParameterKey":"QSS3BucketName",
-        "ParameterValue": "$[taskcat_autobucket]"
-    },
-    {
-        "ParameterKey":"QSS3BucketRegion",
-        "ParameterValue": "us-east-1"
-    },
-    {
-        "ParameterKey":"QSS3KeyPrefix",
-        "ParameterValue": "quickstart-atlassian-crowd/"
-    },
-    {
-        "ParameterKey": "AccessCIDR",
-        "ParameterValue": "10.0.0.0/16"
-    },
-    {
         "ParameterKey": "KeyPairName",
         "ParameterValue": "replaced-by-taskcat-override-file"
     },
     {
-        "ParameterKey": "ExportPrefix",
-        "ParameterValue": "TASI"
+        "ParameterKey": "CidrBlock",
+        "ParameterValue": "0.0.0.0/0"
+    },
+    {
+        "ParameterKey": "QSS3BucketName",
+        "ParameterValue": "$[taskcat_autobucket]"
+    },
+    {
+        "ParameterKey":"QSS3BucketRegion",
+        "ParameterValue":"us-east-1"
+    },
+    {
+        "ParameterKey": "QSS3KeyPrefix",
+        "ParameterValue": "quickstart-atlassian-crowd/"
+    },
+    {
+        "ParameterKey": "ClusterNodeInstanceType",
+        "ParameterValue": "t3.medium"
+    },
+    {
+        "ParameterKey": "DBInstanceClass",
+        "ParameterValue": "db.t3.medium"
+    },
+    {
+        "ParameterKey": "EncryptionAtRest",
+        "ParameterValue": "false"
     }
 ]

--- a/ci/params/encryption/taskcat.yml
+++ b/ci/params/encryption/taskcat.yml
@@ -1,0 +1,16 @@
+---
+global:
+  marketplace-ami: false
+  owner: dc-deployments-syd@atlassian.com
+  qsname: quickstart-atlassian-crowd
+  regions:
+    - ap-southeast-2
+  reporting: true
+
+tests:
+  crowd-encrypted:
+    parameter_input: params/encryption/quickstart-crowd-encrypted-params.json
+    template_file: quickstart-crowd-dc.template.yaml
+  crowd-not-encrypted:
+    parameter_input: params/encryption/quickstart-crowd-not-encrypted-params.json
+    template_file: quickstart-crowd-dc.template.yaml

--- a/ci/quickstart-crowd-dc-not-encrypted-params.json
+++ b/ci/quickstart-crowd-dc-not-encrypted-params.json
@@ -49,6 +49,10 @@
     },
     {
         "ParameterKey": "ExportPrefix",
-        "ParameterValue": "TASI"
+        "ParameterValue": "SASI"
+    },
+    {
+        "ParameterKey": "EncryptionAtRest",
+        "ParameterValue": "false"
     }
 ]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -3,10 +3,14 @@ global:
   owner: quickstart-eng@amazon.com
   qsname: quickstart-atlassian-crowd
   regions:
-    - us-east-1 
+    - us-east-2
   reporting: true
 
 tests:
   crowd:
     parameter_input: quickstart-crowd-dc-params.json
+    template_file: quickstart-crowd-dc-with-vpc.template.yaml
+
+  crowd-not-encrypted:
+    parameter_input: quickstart-crowd-dc-not-encrypted-params.json
     template_file: quickstart-crowd-dc-with-vpc.template.yaml

--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -27,6 +27,7 @@ Metadata:
           - DeploymentAutomationPlaybook
           - DeploymentAutomationKeyName
           - DeploymentAutomationCustomParams
+          - EncryptionAtRest
       - Label:
           default: Database
         Parameters:
@@ -36,7 +37,6 @@ Metadata:
           - DBMultiAZ
           - DBPassword
           - DBStorage
-          - DBStorageEncrypted
           - DBStorageType
       - Label:
           default: Bastion host provisioning
@@ -116,8 +116,6 @@ Metadata:
         default: Application user database password *
       DBStorage:
         default: Database storage
-      DBStorageEncrypted:
-        default: Database encryption
       DBStorageType:
         default: Database storage type
       DeploymentAutomationRepository:
@@ -130,6 +128,8 @@ Metadata:
         default: SSH key name to use with repository
       DeploymentAutomationCustomParams:
         default: Custom command-line parameters for Ansible
+      EncryptionAtRest:
+        default: Database and filesystem encryption
       ExportPrefix:
         default: ASI identifier
       HostedZone:
@@ -394,12 +394,12 @@ Parameters:
     Default: 200
     Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144 GB.
     Type: Number
-  DBStorageEncrypted:
-    Default: "false"
+  EncryptionAtRest:
+    Default: "true"
     AllowedValues:
       - "true"
       - "false"
-    Description: Whether or not to encrypt the database.
+    Description: Whether or not to encrypt the database and filesystems.
     Type: String
   DBStorageType:
     Default: General Purpose (SSD)
@@ -601,8 +601,8 @@ Parameters:
     Type: String
 
 Conditions:
-  UseDatabaseEncryption:
-    !Equals [!Ref DBStorageEncrypted, true]
+  UseEncryption:
+    !Equals [!Ref EncryptionAtRest, true]
   UsingDefaultBucket: 
     !Equals [!Ref QSS3BucketName, 'aws-quickstart']
   KeyProvided:
@@ -645,6 +645,7 @@ Resources:
         - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
           S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
       Parameters:
+        BastionHostRequired: !Ref 'BastionHostRequired'
         CatalinaOpts: !Ref 'CatalinaOpts'
         CidrBlock: !Ref 'AccessCIDR'
         CloudWatchIntegration: !Ref 'CloudWatchIntegration'
@@ -660,7 +661,6 @@ Resources:
         DBMultiAZ: !Ref 'DBMultiAZ'
         DBPassword: !Ref 'DBPassword'
         DBStorage: !Ref 'DBStorage'
-        DBStorageEncrypted: !Ref 'DBStorageEncrypted'
         DBStorageType: !Ref 'DBStorageType'
         DeploymentAutomationRepository: !Ref 'DeploymentAutomationRepository'
         DeploymentAutomationBranch: !Ref 'DeploymentAutomationBranch'
@@ -678,6 +678,7 @@ Resources:
         QSS3KeyPrefix: !Ref 'QSS3KeyPrefix'
         QSS3BucketRegion: !Ref 'QSS3BucketRegion'
         SSLCertificateARN: !Ref 'SSLCertificateARN'
+        EncryptionAtRest: !Ref 'EncryptionAtRest'
         TomcatAcceptCount: !Ref 'TomcatAcceptCount'
         TomcatConnectionTimeout: !Ref 'TomcatConnectionTimeout'
         TomcatContextPath: !Ref 'TomcatContextPath'
@@ -687,7 +688,6 @@ Resources:
         TomcatMinSpareThreads: !Ref 'TomcatMinSpareThreads'
         TomcatProtocol: !Ref 'TomcatProtocol'
         TomcatRedirectPort: !Ref 'TomcatRedirectPort'
-        BastionHostRequired: !Ref 'BastionHostRequired'
 
 Outputs:
   ServiceURL:
@@ -706,10 +706,10 @@ Outputs:
   DBEndpointAddress:
     Description: The database connection string.
     Value: !GetAtt 'CrowdDCStack.Outputs.DBEndpointAddress'
-  DBEncryptionKey:
-    Condition: UseDatabaseEncryption
-    Description: The alias of the encryption key created for Amazon RDS.
-    Value: !GetAtt 'CrowdDCStack.Outputs.DBEncryptionKey'
+  EncryptionKey:
+    Condition: UseEncryption
+    Description: The alias of the encryption key created for Amazon RDS and EFS.
+    Value: !GetAtt 'CrowdDCStack.Outputs.EncryptionKey'
   EFSCname:
     Description: The CNAME of the Amazon Elastic File System (Amazon EFS).
     Value: !GetAtt 'CrowdDCStack.Outputs.EFSCname'

--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -27,7 +27,6 @@ Metadata:
           - DeploymentAutomationPlaybook
           - DeploymentAutomationKeyName
           - DeploymentAutomationCustomParams
-          - EncryptionAtRest
       - Label:
           default: Database
         Parameters:
@@ -39,21 +38,22 @@ Metadata:
           - DBStorage
           - DBStorageType
       - Label:
-          default: Bastion host provisioning
+          default: Security
         Parameters:
+          - AccessCIDR
+          - EncryptionAtRest
+          - SSLCertificateARN
           - BastionHostRequired
           - KeyPairName
       - Label:
           default: Networking
         Parameters:
-          - AccessCIDR
           - AvailabilityZones
           - InternetFacingLoadBalancer
           - PrivateSubnet1CIDR
           - PrivateSubnet2CIDR
           - PublicSubnet1CIDR
           - PublicSubnet2CIDR
-          - SSLCertificateARN
           - VPCCIDR
       - Label:
           default: DNS (Optional)

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -23,7 +23,6 @@ Metadata:
           - DeploymentAutomationPlaybook
           - DeploymentAutomationCustomParams
           - DeploymentAutomationKeyName
-          - EncryptionAtRest
       - Label:
           default: Database
         Parameters:
@@ -36,16 +35,17 @@ Metadata:
           - DBStorage
           - DBStorageType
       - Label:
-          default: Bastion host utilization
+          default: Security
         Parameters:
+          - CidrBlock
+          - EncryptionAtRest
+          - SSLCertificateARN
           - BastionHostRequired
           - KeyPairName
       - Label:
           default: Networking
         Parameters:
           - InternetFacingLoadBalancer
-          - CidrBlock
-          - SSLCertificateARN
       - Label:
           default: DNS
         Parameters:
@@ -961,10 +961,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
+          Value: "COMMIT: 32b8c189b968f105f36ccbc6ff9a54153bae6806"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
+          Value: "TIMESTAMP: 2020-09-03T01:43:07Z"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1136,9 +1136,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
+          Value: "COMMIT: 32b8c189b968f105f36ccbc6ff9a54153bae6806"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
+          Value: "TIMESTAMP: 2020-09-03T01:43:07Z"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1226,9 +1226,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
+          Value: "COMMIT: 32b8c189b968f105f36ccbc6ff9a54153bae6806"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
+          Value: "TIMESTAMP: 2020-09-03T01:43:07Z"
 
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -1290,9 +1290,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
+          Value: "COMMIT: 32b8c189b968f105f36ccbc6ff9a54153bae6806"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
+          Value: "TIMESTAMP: 2020-09-03T01:43:07Z"
     DependsOn:
       - LoadBalancer
   LoadBalancerCname:
@@ -1371,9 +1371,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
+          Value: "COMMIT: 32b8c189b968f105f36ccbc6ff9a54153bae6806"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
+          Value: "TIMESTAMP: 2020-09-03T01:43:07Z"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:
@@ -1405,9 +1405,9 @@ Resources:
           Value: !Sub ["${StackName} Encryption Key", {StackName: !Ref 'AWS::StackName'}]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
+          Value: "COMMIT: 32b8c189b968f105f36ccbc6ff9a54153bae6806"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
+          Value: "TIMESTAMP: 2020-09-03T01:43:07Z"
   EncryptionKeyAlias:
     Condition: UseEncryption
     Type: AWS::KMS::Alias

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -23,6 +23,7 @@ Metadata:
           - DeploymentAutomationPlaybook
           - DeploymentAutomationCustomParams
           - DeploymentAutomationKeyName
+          - EncryptionAtRest
       - Label:
           default: Database
         Parameters:
@@ -33,7 +34,6 @@ Metadata:
           - DBMultiAZ
           - DBPassword
           - DBStorage
-          - DBStorageEncrypted
           - DBStorageType
       - Label:
           default: Bastion host utilization
@@ -105,8 +105,6 @@ Metadata:
         default: Application user database password *
       DBStorage:
         default: Database storage
-      DBStorageEncrypted:
-        default: Database encryption
       DBStorageType:
         default: Database storage type
       DeploymentAutomationRepository:
@@ -119,6 +117,8 @@ Metadata:
         default: SSH key name to use with the repository
       DeploymentAutomationCustomParams:
         default: Custom command-line parameters for Ansible
+      EncryptionAtRest:
+        default: Database and filesystem encryption
       ExportPrefix:
         default: ASI identifier
       HostedZone:
@@ -377,13 +377,6 @@ Parameters:
     Default: 200
     Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144 GB.
     Type: Number
-  DBStorageEncrypted:
-    Default: "false"
-    AllowedValues:
-      - "true"
-      - "false"
-    Description: Whether or not to encrypt the database.
-    Type: String
   DBStorageType:
     Default: General Purpose (SSD)
     AllowedValues:
@@ -412,6 +405,13 @@ Parameters:
     Default: ""
     Type: String
     Description: (Optional) Key pair name to use with this repository. The key should be imported into the AWS Systems Manager parameter store. 
+  EncryptionAtRest:
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+    Description: Whether or not to encrypt the database and filesystems.
+    Type: String
   ExportPrefix:
     Default: 'ATL-'
     Description:
@@ -565,8 +565,8 @@ Conditions:
     !Not [!Equals [!Ref TomcatContextPath, '']]
   UseCustomDnsName:
     !Not [!Equals [!Ref CustomDnsName, '']]
-  UseDatabaseEncryption:
-    !Equals [!Ref DBStorageEncrypted, true]
+  UseEncryption:
+    !Equals [!Ref EncryptionAtRest, true]
   UseHostedZone:
     !Not [!Equals [!Ref HostedZone, '']]
   UsePublicIp:
@@ -961,10 +961,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
           PropagateAtLaunch: true
 
   ClusterNodeLaunchConfig:
@@ -1094,6 +1094,7 @@ Resources:
         - DeviceName: /dev/xvda
           Ebs:
             VolumeSize: !Ref ClusterNodeVolumeSize
+            Encrypted: !Ref EncryptionAtRest
         - DeviceName: /dev/xvdf
           NoDevice: true
       KeyName: !If
@@ -1126,6 +1127,8 @@ Resources:
   ElasticFileSystem:
     Type: AWS::EFS::FileSystem
     Properties:
+      Encrypted: !Ref EncryptionAtRest
+      KmsKeyId: !If [UseEncryption, !GetAtt EncryptionKey.Arn, !Ref 'AWS::NoValue']
       FileSystemTags:
         - Key: Name
           Value: !Join [' ', [!Ref 'AWS::StackName', 'cluster shared-files']]
@@ -1133,9 +1136,9 @@ Resources:
           Value: !Ref AWS::StackId
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
   EFSMountAz1:
     Type: AWS::EFS::MountTarget
     Properties:
@@ -1186,7 +1189,7 @@ Resources:
         DBMasterUserPassword: !Ref DBMasterUserPassword
         DBMultiAZ: !Ref DBMultiAZ
         DBSecurityGroup: !Ref SecurityGroup
-        DBStorageEncrypted: !Ref DBStorageEncrypted
+        DBStorageEncrypted: !Ref EncryptionAtRest
         DBStorageType: !Ref DBStorageType
         ExportPrefix: !Ref ExportPrefix
         QSS3BucketName: !Ref QSS3BucketName
@@ -1223,9 +1226,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
 
   LoadBalancerHTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -1287,9 +1290,9 @@ Resources:
           Value: !Ref AWS::StackName
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
     DependsOn:
       - LoadBalancer
   LoadBalancerCname:
@@ -1368,9 +1371,9 @@ Resources:
           Value: !Join [' ', [!Ref "AWS::StackName", 'sg']]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
       VpcId:
         Fn::ImportValue: !Sub "${ExportPrefix}VPCID"
   SecurityGroupIngress:
@@ -1382,7 +1385,7 @@ Resources:
       ToPort: -1
       SourceSecurityGroupId: !Ref SecurityGroup
   EncryptionKey:
-    Condition: UseDatabaseEncryption
+    Condition: UseEncryption
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: AWS::KMS::Key
@@ -1402,11 +1405,11 @@ Resources:
           Value: !Sub ["${StackName} Encryption Key", {StackName: !Ref 'AWS::StackName'}]
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: 35bde08129b5af2b4dc805dcdc9c944f9d459ba0"
+          Value: "COMMIT: 693e2ad878d0bb61498a30fc7c6665818e1886f9"
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-09-01T04:02:21Z"
+          Value: "TIMESTAMP: 2020-09-03T00:05:58Z"
   EncryptionKeyAlias:
-    Condition: UseDatabaseEncryption
+    Condition: UseEncryption
     Type: AWS::KMS::Alias
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}"
@@ -1473,9 +1476,9 @@ Outputs:
   DBEndpointAddress:
     Description: The database connection string.
     Value: !GetAtt DB.Outputs.RDSEndPointAddress
-  DBEncryptionKey:
-    Condition: UseDatabaseEncryption
-    Description: The alias of the encryption key created for Amazon RDS.
+  EncryptionKey:
+    Condition: UseEncryption
+    Description: The alias of the encryption key created for Amazon RDS and EFS
     Value: !Ref EncryptionKeyAlias
   EFSCname:
     Description: The CNAME of the Amazon Elastic File System (Amazon EFS).


### PR DESCRIPTION
* Add `EncryptionAtRest` parameter
* EFS and RDS will use newly generated customer KMS key - this was the case previously for RDS only
* EBS will use default AWS encryption key (`aws/ebs`)
* Encryption is enabled by default
* Added params for encryption (although this implicitly changes the default params as well as we encrypt at rest by default now).