### PR TITLE
DCD-1316: ssh key description update

### DIFF
--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -464,8 +464,8 @@ Parameters:
     Description: Whether to provision a bastion host instance. If 'true', provide an Amazon EC2 key pair (otherwise, you won't be able to use the bastion host to access Crowd instances).
     Type: String
   KeyPairName:
-    ConstraintDescription: Must be the name of an existing Amazon EC2 key pair.
-    Description: Public/private EC2 key pairs to securely access the bastion host.
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair. Note the supplied value must not include the file extension.
+    Description: Public/private EC2 Key Pairs (without file extension) to allow you to securely access the Bastion host.
     Type: String
     Default: ''
   MailEnabled:

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -447,8 +447,8 @@ Parameters:
     Description: Whether to grant access to Crowd's Amazon EC2 instances through the ASI's bastion host (if it exists). If 'true', remember to provide an EC2 key pair. If your ASI does not have a bastion host, set the value to 'false'.
     Type: String
   KeyPairName:
-    ConstraintDescription: Must be the name of an existing Amazon EC2 key pair.
-    Description: Public/private EC2 key pairs for securely accessing the bastion host.
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair. Note the supplied value must not include the file extension.
+    Description: Public/private EC2 Key Pairs (without file extension) to allow you to securely access the Bastion host.
     Type: String
     Default: ''
   MailEnabled:


### PR DESCRIPTION
Description of the 'key Pairs Name SSH' field modified to reduce the confusion during Quickstart set up.