### PR TITLE
W9003 excluded

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -14,5 +14,7 @@ ignore_checks:
   # W9006: Parameter Description is not sentence case
   # W9006: Parameter contains spelling error(s)
   - W9006
+  # W9003 Parameter is not in a ParameterGroup
+  - W9003
   # EIAMPolicyWildcardResource: IAM policy should not allow * resource; This method in this in this policy support granular permissions
   - EIAMPolicyWildcardResource


### PR DESCRIPTION
This rule did not show up when running cfn-lint locally.