### PR TITLE
DCD-1434: Removed version 9 from DBEngineVersion

### DIFF
--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -312,10 +312,11 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
+      - 9
       - 10
       - 11
       - 12
-    Description: "The database engine version to use. A suitable minor version is installed for your chosen engine. Make sure that the installed Crowd version supports the database engine selected."
+    Description: "The database engine version to use. A suitable minor version is installed for your chosen engine. Make sure that the installed Crowd version supports the database engine selected. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-crowd-dc-with-vpc.template.yaml
+++ b/templates/quickstart-crowd-dc-with-vpc.template.yaml
@@ -312,7 +312,6 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
-      - 9
       - 10
       - 11
       - 12

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -295,10 +295,11 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
+      - 9
       - 10
       - 11
       - 12
-    Description: "The database engine version to use. A suitable minor version is installed for your chosen engine. Make sure that the installed Crowd version supports the database engine selected."
+    Description: "The database engine version to use. A suitable minor version is installed for your chosen engine. Make sure that the installed Crowd version supports the database engine selected. (Warning: Amazon RDS for PostgreSQL 9.6 will reach end of life on January 31st, 2022. Deployments after this date should not be made using this version. If you wish to upgrade to a major version from 9 see: https://confluence.atlassian.com/x/1IRlQQ)"
     Type: String
   DBInstanceClass:
     Default: db.m5.large

--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -295,7 +295,6 @@ Parameters:
   DBEngineVersion:
     Default: 10
     AllowedValues:
-      - 9
       - 10
       - 11
       - 12


### PR DESCRIPTION
Remove Postgres version 9 as the version will be EOL