### PR TITLE
DCD-956 Creation policy to wait until all the instances are up and running

### DIFF
--- a/templates/quickstart-crowd-dc.template.yaml
+++ b/templates/quickstart-crowd-dc.template.yaml
@@ -951,6 +951,10 @@ Resources:
   # Crowd node config
   ClusterNodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    CreationPolicy:
+      ResourceSignal:
+        Count: !Ref ClusterNodeMin
+        Timeout: PT15M
     Properties:
       DesiredCapacity: !Ref ClusterNodeMin
       LaunchConfigurationName: !Ref ClusterNodeLaunchConfig


### PR DESCRIPTION
DCD-956 Creation policy to wait until all the instances are up and running